### PR TITLE
terms page, error popup, style fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,4 @@ dist
 /.idea/
 
 .DS_Store
+.vscode/launch.json

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -3,27 +3,27 @@
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.svg" />
-    <meta name="viewport" content="width=500, shrink-to-fit=yes">
+    <meta name="viewport" content="width=500, shrink-to-fit=yes, maximum-scale=1, user-scalable=0">
     <meta name="theme-color" content="#000000" />
-    <meta name="description" content=""/>
+    <meta name="description" content="Something big is about to drop. Know a project or someone deserving?"/>
 
         <!-- Primary Meta Tags -->
     <meta name="title" content="DAO Drops">
-    <meta name="description" content="">
+    <meta name="description" content="Something big is about to drop. Know a project or someone deserving?">
 
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
-    <meta property="og:url" content="">
+    <meta property="og:url" content="https://daodrops.io">
     <meta property="og:title" content="DAO Drops">
-    <meta property="og:description" content=" ">
-    <meta property="og:image" content="">
+    <meta property="og:description" content="Something big is about to drop. Know a project or someone deserving?">
+    <!-- <meta property="og:image" content=""> -->
 
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image">
-    <meta property="twitter:url" content="">
+    <meta property="twitter:url" content="https://daodrops.io">
     <meta property="twitter:title" content="DAO Drops">
-    <meta property="twitter:description" content="">
-    <meta property="twitter:image" content="">
+    <meta property="twitter:description" content="Something big is about to drop. Know a project or someone deserving?">
+    <!-- <meta property="twitter:image" content=""> -->
 
     <title>DAO Drops</title>
   </head>

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -3,8 +3,9 @@ import Phase1 from './components/Phase1'
 import Phase2 from './components/Phase2'
 import Phase3 from './components/Phase3'
 import Pause from './components/Pause'
+import Terms from './components/Terms'
 import axios from 'axios'
-import { BrowserRouter, Routes, Route } from 'react-router-dom'
+import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
 import { providers } from 'ethers'
 import Web3Token from 'web3-token'
 import Web3Modal from 'web3modal'
@@ -31,38 +32,38 @@ const App = () => {
     const [phaseView, setPhaseView] = useState('1')
   
     useEffect(() => {
-      address && points !== null && localStorage.setItem(`points_${address}`, points)
+      address && points !== null && localStorage.setItem(`points_${address}`, parseInt(points))
     }, [address, points])
 
     useEffect(() => {
       address && votes !== null && localStorage.setItem(`votes_${address}`, JSON.stringify(votes))
     }, [address, votes])
 
-    useEffect(() => {
-      const providerOptions = {
-        walletconnect: {
-          package: WalletConnectProvider,
-          options: {
-            infuraId: INFURA_ID,
-          }
-        },
-      }
+    // useEffect(() => {
+    //   const providerOptions = {
+    //     walletconnect: {
+    //       package: WalletConnectProvider,
+    //       options: {
+    //         infuraId: INFURA_ID,
+    //       }
+    //     },
+    //   }
   
-      const newWeb3Modal = new Web3Modal({
-        cacheProvider: true,
-        network: 'mainnet',
-        providerOptions,
-        // theme: 'dark',
-      })
+    //   const newWeb3Modal = new Web3Modal({
+    //     cacheProvider: true,
+    //     network: 'mainnet',
+    //     providerOptions,
+    //     // theme: 'dark',
+    //   })
   
-      setWeb3Modal(newWeb3Modal)
-    }, [])
+    //   setWeb3Modal(newWeb3Modal)
+    // }, [])
   
-    useEffect(() => {
-      if(web3Modal && web3Modal.cachedProvider){
-        loadWeb3('load')
-      }
-    }, [web3Modal])
+    // useEffect(() => {
+    //   if(web3Modal && web3Modal.cachedProvider){
+    //     loadWeb3('load')
+    //   }
+    // }, [web3Modal])
   
     async function sign(token, eSigner) {
       token = await Web3Token.sign(async msg => await eSigner.signMessage(msg), {
@@ -102,7 +103,7 @@ const App = () => {
               setAddressDetails(r.data)
 
               let pointsStorage = localStorage.getItem(`points_${ethAddress}`)
-              pointsStorage ? setPoints(pointsStorage) : setPoints(r.data['score'])
+              pointsStorage ? setPoints(parseInt(pointsStorage)) : setPoints(parseInt(r.data['score']))
 
               r.data.picks.length && r.data.picks.map( pick => setVotes(votes => ({...votes, [pick.id]: pick.points})) )
           }
@@ -113,6 +114,16 @@ const App = () => {
         })
 
       setWalletStatus('connected')
+    }
+
+    function clearAddress() {
+      setAddress('')
+      setPoints(null)
+      setVotes(null)
+      localStorage.removeItem(address)
+      localStorage.removeItem(`points_${address}`)
+      localStorage.removeItem(`votes_${address}`)
+      setWalletStatus('disconnected')
     }
 
     async function addListeners(web3ModalProvider) {
@@ -130,11 +141,7 @@ const App = () => {
       
       web3ModalProvider.on('disconnect', (error) => {
         web3Modal.clearCachedProvider()
-        localStorage.removeItem(address)
-        localStorage.removeItem(`points_${address}`)
-        localStorage.removeItem(`votes_${address}`)
-        setAddress('')
-        setWalletStatus('disconnected')
+        clearAddress()
         // window.location.reload()
         console.log(error)
       })
@@ -142,11 +149,7 @@ const App = () => {
 
     async function disconnectWeb3() {
       await web3Modal.clearCachedProvider()
-      localStorage.removeItem(address)
-      localStorage.removeItem(`points_${address}`)
-      localStorage.removeItem(`votes_${address}`)
-      setAddress('')
-      setWalletStatus('disconnected')
+      clearAddress()
     }
 
     return(
@@ -158,10 +161,12 @@ const App = () => {
 
         <BrowserRouter>
           <Routes>
-            <Route path='/' element={<Phase1 setPhaseView={setPhaseView} />} />
-            <Route path='2' element={<Phase2 loadWeb3={loadWeb3} disconnectWeb3={disconnectWeb3} signer={signer} address={address} addressDetails={addressDetails} walletStatus={walletStatus} points={points} setPoints={setPoints} votes={votes} setVotes={setVotes} setPhaseView={setPhaseView} />} />
-            <Route path='3' element={<Phase3 loadWeb3={loadWeb3} disconnectWeb3={disconnectWeb3} address={address} addressDetails={addressDetails} walletStatus={walletStatus} />} />
-            <Route path='/p' element={<Pause />} />
+            <Route path='/' element={phaseView === '1' ? <Phase1 setPhaseView={setPhaseView} /> : phaseView === 'p' ? <Pause /> : <Phase1 setPhaseView={setPhaseView} /> } />
+            {/* <Route path='2' element={<Phase2 loadWeb3={loadWeb3} disconnectWeb3={disconnectWeb3} signer={signer} address={address} addressDetails={addressDetails} walletStatus={walletStatus} points={points} setPoints={setPoints} votes={votes} setVotes={setVotes} setPhaseView={setPhaseView} />} /> */}
+            {/* <Route path='3' element={<Phase3 loadWeb3={loadWeb3} disconnectWeb3={disconnectWeb3} address={address} addressDetails={addressDetails} walletStatus={walletStatus} />} /> */}
+            {/* <Route path='/p' element={<Pause />} /> */}
+            <Route path='/terms' element={<Terms />} />
+            <Route path="*" element={<Navigate to="/" replace />} />
           </Routes>
         </BrowserRouter>
 

--- a/client/src/Utils.js
+++ b/client/src/Utils.js
@@ -33,3 +33,6 @@ export const shuffle = (array) => {
 }
 
 export const withHttp = url => !/^https?:\/\//i.test(url) ? `http://${url}` : url;
+
+export const numberWithCommas = x => x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+     

--- a/client/src/components/ErrorPopup.js
+++ b/client/src/components/ErrorPopup.js
@@ -1,0 +1,29 @@
+import React, { useState } from 'react'
+import closeIcon from '../assets/icons/close.svg'
+
+// Error Popup Component
+// ------------------------------------------------------------------------------------------------------- //
+const ErrorPopup = ({errorPopupStatus, setErrorPopupStatus}) => {
+
+  return (
+    <div className='flex items-center justify-center fixed inset-0 bg-popupOverlay z-30' id='error-popup-overlay' 
+         onClick={(e) => e.target === document.querySelector('#error-popup-overlay') ? (document.querySelector('#error-popup-overlay').style.display = 'none', setErrorPopupStatus(false)) : null}>
+        <div className='popup-mobile 800px:popup scale-[85%] 600px:scale-100' style={{backgroundPosition: '0 -75px'}}>
+            <img className='absolute right-3 top-3 cursor-pointer hover:brightness-75' src={closeIcon} alt='Close Popup' 
+                 onClick={() => {document.querySelector('#error-popup-overlay').style.display = 'none'; setErrorPopupStatus(false); }} />
+
+            <div className='rounded-t-[4.5rem] mt-[10rem] px-12 800px:px-16 py-8 bg-white w-full h-[calc(100%-10rem)]'>
+            
+            <div className='flex flex-col my-16 1000px:my-[100px] justify-center items-center'>
+                <h3 className='font-ibm 800px:font-obWide font-bold 800px:font-semibold leading-[2.7rem] mb-14 text-center text-3xl'>We've encountered an issue!</h3>
+                <div className='font-ibm font-semibold text-2xl text-gray6 text-center'>Please refresh your page and try again in a few minutes.</div>
+
+            </div>
+            </div>
+
+        </div>
+    </div>
+)}
+// ------------------------------------------------------------------------------------------------------- //
+
+export default ErrorPopup;

--- a/client/src/components/Pause/index.js
+++ b/client/src/components/Pause/index.js
@@ -36,7 +36,7 @@ const Pause = () => {
               <div className='flex flex-col'>
                 <div className='ml-8 600px:ml-12 mt-10 z-10'>
                   <h3 className='text-3xl h870px:text-[calc(1.1rem+1vw)] 600px:text-4xl 1000px:text-[calc(1.4rem+1vw)] mb-6 leading-10'>pause time</h3>
-                  <div className='font-obWide font-medium text-base 1000px:text-[calc(0.5rem+0.55vw)] leading-snug 1000px:w-[70%]'>we received all the amazing nominations and now they are being curated. Stay tuned for the next phase in: <a className='underline hover:text-indigoDD2 font-semibold' href={constants.Twitter} target='_blank' rel='noreferrer'> DAO drops twitter.</a></div>
+                  <div className='font-obWide font-medium text-base 1000px:text-[calc(0.5rem+0.55vw)] leading-snug 1000px:w-[70%]'>we received all the amazing nominations and now they are being curated. Stay tuned for the next phase in: <a className='underline text-magentaDD5 hover:text-magentaDD4 font-semibold' href={constants.Twitter} target='_blank' rel='noreferrer'> DAO drops twitter.</a></div>
                 </div>
 
                 <div className='ml-8 600px:ml-12 w-auto border-[6px] border-indigoDD z-10 relative !min-h-[20.5rem] mt-14' style={{height: `calc(100vh - ${height+350}px)`}}>
@@ -58,13 +58,13 @@ const Pause = () => {
           </div>
 
           <div className='flex pb-8 1000px:p-0 flex-wrap 1000px:flex-nowrap' ref={ref}>
-            <div className='mt-44 1000px:mt-[6.25rem] order-2 1000px:order-1 w-full 1000px:w-auto relative'>
-                <div className='font-ob text-magentaDD text-xl 1000px:text-sm border-b border-magentaDD pb-4 w-full 1000px:w-[19rem]'>
-                  Built by <a target='_blank' rel='noreferrer' href='https://www.dorg.tech' className='font-semibold hover:underline'>dOrg</a> and funded<br/>
+            <div className='mt-44 1000px:mt-[6.25rem] order-2 1000px:order-1 w-auto relative'>
+                <div className='font-ob text-magentaDD text-sm border-b border-magentaDD pb-4 w-[19rem]'>
+                  Built by <a target='_blank' rel='noreferrer' href='https://www.dorg.tech' className='font-semibold hover:underline'>dOrg</a> and supported<br/>
                   by the <a target='_blank' rel='noreferrer' href='https://ethereum.foundation' className='font-semibold hover:underline'>Ethereum Foundation</a>
                 </div>
 
-                <div className='1000px:mt-2.5 absolute 1000px:relative right-4 top-4 1000px:inset-0 scale-150 1000px:scale-100'>
+                <div className='mt-2.5 relative inset-0'>
                   <a target='_blank' rel='noreferrer' href={constants.Twitter}>
                     <img className='inline hover:scale-105' src={twitter} alt='Twitter' />
                   </a>

--- a/client/src/components/Phase1/NominatePopup.js
+++ b/client/src/components/Phase1/NominatePopup.js
@@ -12,14 +12,16 @@ dotenv.config()
 
 // Nominate Popup Component (Phase1)
 // ------------------------------------------------------------------------------------------------------- //
-const NominatePopup = ({ popupStatus, setPopupStatus }) => {
+const NominatePopup = ({ popupStatus, setPopupStatus, setErrorPopupStatus }) => {
 
     const CAPTCHA_SITE_KEY = process.env.REACT_APP_CAPTCHA_SITE_KEY
     const POSTS = 'https://dao-drops.herokuapp.com/posts'
+    // const POSTS = 'https://httpstat.us/500'
 
     const newProject = { name: '', message: '', link: '', contactMethod: 'email', contact: '', image: null }
     const [projectData, setProjectData] = useState(newProject)
     const captchaRef = useRef(null)
+    const descRef = useRef(null)
 
     const submitProject = async e => {
       e.preventDefault()
@@ -27,7 +29,15 @@ const NominatePopup = ({ popupStatus, setPopupStatus }) => {
       captchaRef.current.reset()
       axios.post(POSTS, projectData, { headers: { 'captcha-token': captchaToken }})
             .then(r => { r.status === 201 && setPopupStatus('submitted')} )
-            .catch(e => console.error(e))
+            .catch(function (error) {
+              if (error.response && error.response.status === 500) {
+                setPopupStatus('hidden')
+                setErrorPopupStatus(true)
+              } else {
+                console.error('Error', error.message)
+              }
+              // console.log(error.config)
+            })
     };
   
     return (
@@ -48,14 +58,17 @@ const NominatePopup = ({ popupStatus, setPopupStatus }) => {
                       <div className='flex mb-4 800px:mb-0'>
                         <div className='flex flex-col justify-end w-full'>
                           <label htmlFor='project-name' className='required'>Project / individual name (yes, you can nominate yourself)</label>
-                          <input className='w-full h-10 mt-1.5 mb-3' type='text' id='project-name' name='project-name' maxLength= '150' value={projectData.name} onChange={ (e) => setProjectData({...projectData, name: e.target.value}) } required />
+                          <input className='w-full h-10 mt-1.5 mb-3' type='text' id='project-name' name='project-name' maxLength= '256' value={projectData.name} onChange={ (e) => setProjectData({...projectData, name: e.target.value}) } required />
                         </div>
                       </div>
 
-                      <label htmlFor='funding-reason' className='required'>Why should they receive the funding? Tell us more!</label>
-                      <textarea className='w-full h-28 mt-1.5 mb-2' id='funding-reason' name='funding-reason' maxLength= '1400' value={projectData.message} onChange={ (e) => setProjectData({...projectData, message: e.target.value}) } required />
+                      <span className='flex gap-3'>
+                        <label htmlFor='funding-reason' className='required'>Why should they receive the funding? Tell us more!</label>
+                        <span className='ml-auto my-auto text-xs text-gray4 font-semibold'>{descRef.current ? 1000 - descRef.current.value.length : '1000'} Char Left</span>
+                      </span>
+                      <textarea ref={descRef} className='w-full h-28 mt-1.5 mb-2' id='funding-reason' name='funding-reason' maxLength= '1000' value={projectData.message} onChange={ (e) => setProjectData({...projectData, message: e.target.value}) } required />
 
-                      <label htmlFor='website'>Link to website/Gitcoin (optional)</label>
+                      <label htmlFor='website'>Link to website (optional)</label>
                       <input className='w-full h-10 mt-1.5 mb-3' type='text' id='website' name='website' maxLength= '2084' value={projectData.link} onChange={ (e) => setProjectData({...projectData, link: e.target.value}) }  />
 
                       <label htmlFor='contact' className='required'>Contact of project / individual (for verification)</label>
@@ -65,14 +78,20 @@ const NominatePopup = ({ popupStatus, setPopupStatus }) => {
                           <option value='twitter'>twitter</option>
                           <option value='discord'>discord</option>
                         </select>
-                        <input className='w-full h-10' type='text' id='contact' name='contact' maxLength= '150' placeholder={projectData.contactMethod === 'email' ? 'example@example.com' : projectData.contactMethod === 'twitter' ? '@example' : 'Example@3456'} value={projectData.contact} onChange={ (e) => setProjectData({...projectData, contact: e.target.value}) } required />
+                        <input className='w-full h-10' type='text' id='contact' name='contact' maxLength= '256' placeholder={projectData.contactMethod === 'email' ? 'example@example.com' : projectData.contactMethod === 'twitter' ? '@example' : 'Example#3456'} value={projectData.contact} onChange={ (e) => setProjectData({...projectData, contact: e.target.value}) } required />
                       </div>
 
                       <div className='recaptcha'>
                         <ReCAPTCHA sitekey={CAPTCHA_SITE_KEY} ref={captchaRef} size='invisible' />
                       </div>
 
-                      <button className='button2 ml-auto' type='submit'>Submit</button>
+                      <div className='flex items-center gap-3'>
+                        <span>
+                          <input type='checkbox' name='terms' id='terms' required/>
+                          <label htmlFor='terms' className='ml-2 required'>I agree to the <a target='_blank' rel='noreferrer' href='/terms' className='underline'> terms and conditions</a></label>
+                        </span>    
+                        <button className='button2 ml-auto' type='submit'>Submit</button>
+                      </div>
                     </form>
                     
                   </div>

--- a/client/src/components/Phase1/index.js
+++ b/client/src/components/Phase1/index.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react'
 import NominatePopup from './NominatePopup'
+import ErrorPopup from '../ErrorPopup'
 import * as constants from '../../Constants'
 import Countdown from 'react-countdown'
 
@@ -19,9 +20,11 @@ import twitter from '../../assets/icons/twitter.svg'
 // Phase1 Component
 // ------------------------------------------------------------------------------------------------------- //
 const Phase1 = ({setPhaseView}) => {
+  const [errorPopupStatus, setErrorPopupStatus] = useState(false)
+
   const [isVideoLoaded, setIsVideoLoaded] = useState(false)
   const [popupStatus, setPopupStatus] = useState('hidden')
-  const phase1End = '2022-11-30T00:00:00.000+00:00'
+  const phase1End = '2023-02-03T00:00:00.000+00:00'
   // const phase1End = Date.now() + 10000
 
   const [height, setHeight] = useState(0)
@@ -69,7 +72,7 @@ const Phase1 = ({setPhaseView}) => {
 
                   <div className='absolute bottom-0 z-20 w-full 800px:w-auto'>
                     <div className='w-48 h-10 bg-white border-t-[6px] border-indigoDD text-lg font-ob font-bold uppercase flex justify-center items-center endsin-line'>
-                      <div className='absolute pb-0.5'>PHASE ENDS IN:</div>
+                      <div className='absolute pb-0.5 uppercase text-[15px]'>nomination phase:</div>
                     </div>
 
                     <div className='w-full 800px:w-[32rem] h-[6.5rem] bg-white border-t-[6px] 800px:border-r-[6px] border-indigoDD font-obWide font-extrabold text-5xl flex justify-center items-center'>
@@ -82,13 +85,13 @@ const Phase1 = ({setPhaseView}) => {
           </div>
 
           <div className='flex pb-8 1000px:p-0 flex-wrap 1000px:flex-nowrap' ref={ref}>
-            <div className='mt-20 1000px:mt-[6.25rem] order-2 1000px:order-1 w-full 1000px:w-auto relative'>
-                <div className='font-ob text-magentaDD text-xl 1000px:text-sm border-b border-magentaDD pb-4 w-full 1000px:w-[19rem]'>
-                  Built by <a target='_blank' rel='noreferrer' href='https://www.dorg.tech' className='font-semibold hover:underline'>dOrg</a> and funded<br/>
+            <div className='mt-20 1000px:mt-[6.25rem] order-2 1000px:order-1 w-auto relative'>
+                <div className='font-ob text-magentaDD text-sm border-b border-magentaDD pb-4 w-[19rem]'>
+                  Built by <a target='_blank' rel='noreferrer' href='https://www.dorg.tech' className='font-semibold hover:underline'>dOrg</a> and supported<br/>
                   by the <a target='_blank' rel='noreferrer' href='https://ethereum.foundation' className='font-semibold hover:underline'>Ethereum Foundation</a>
                 </div>
 
-                <div className='1000px:mt-2.5 absolute 1000px:relative right-4 top-4 1000px:inset-0 scale-150 1000px:scale-100'>
+                <div className='mt-2.5 relative inset-0'>
                   <a target='_blank' rel='noreferrer' href={constants.Twitter}>
                     <img className='inline hover:scale-105' src={twitter} alt='Twitter' />
                   </a>
@@ -98,13 +101,15 @@ const Phase1 = ({setPhaseView}) => {
             <div className='1000px:ml-16 mt-32 1000px:mt-7 z-10 order-1 1000px:order-2'>
               <h3 className='text-3xl h870px:text-[calc(1rem+1vw)] 600px:text-4xl 1000px:text-[calc(1.4rem+1vw)] mb-6 leading-10'>something big is about to drop.</h3>
               <div className='subtitle2 hidden 1000px:block text-[calc(0.4rem+1vw)] leading-snug'>know a project or someone deserving?</div>
+              {/* <div className='subtitle2 text-[calc(0.7rem+1vw)] leading-6 800px:leading-7 1000px:leading-snug 1000px:text-[calc(0.4rem+1vw)]'>know a project or someone deserving?</div> */}
               <div className='button1-small 600px:button1 mt-6 1000px:mt-7 1000px:mb-8 h870px:button1-small' onClick={ () => { setPopupStatus('nominate'); } }>Nominate Them</div>
             </div>
           </div>
 
       </div>
 
-      <NominatePopup popupStatus={popupStatus} setPopupStatus={setPopupStatus} />
+      <NominatePopup popupStatus={popupStatus} setPopupStatus={setPopupStatus} setErrorPopupStatus={setErrorPopupStatus} />
+      {errorPopupStatus && <ErrorPopup setErrorPopupStatus={setErrorPopupStatus} />}
     </>
   )}
 // ------------------------------------------------------------------------------------------------------- //

--- a/client/src/components/Phase2/Header.js
+++ b/client/src/components/Phase2/Header.js
@@ -9,10 +9,10 @@ import axios from 'axios'
 
 // Header Component (Phase2)
 // ------------------------------------------------------------------------------------------------------- //
-const Header = ({loadWeb3, disconnectWeb3, signer, address, addressDetails, walletStatus, points, votes, setVotesSubmitted, votesSubmitted}) => {
+const Header = ({loadWeb3, disconnectWeb3, signer, address, addressDetails, walletStatus, points, votes, setVotesSubmitted, votesSubmitted, setErrorPopupStatus}) => {
 
     const SCORE = 'https://dao-drops.herokuapp.com/posts/score/'
-    
+
     const [sendPointsNote, setSendPointsNote] = useState('false')
     const [walletToggle, setWalletToggle] = useState(false);
     const [donePopupStatus, setDonePopupStatus] = useState(false)
@@ -37,8 +37,20 @@ const Header = ({loadWeb3, disconnectWeb3, signer, address, addressDetails, wall
         const picksSubmission = {account: address.toLowerCase(), message: token, score: points, picks: picksSelected}
 
         const url = SCORE + addressDetails._id
-        axios.patch(url, picksSubmission).then(r => { r.status === 200 && setVotesSubmitted('true')} ).catch(e => console.error(e))
-        setDonePopupStatus(true)
+        // const url = 'https://httpstat.us/500'
+
+        axios.patch(url, picksSubmission)
+             .then(r => { r.status === 200 && setVotesSubmitted('true') && setDonePopupStatus(true)} )
+             .catch(function (error) {
+              if (error.response && error.response.status === 500) {
+                setVotesSubmitted('false')
+                disconnectWeb3()
+                setErrorPopupStatus(true)
+              } else {
+                console.error('Error', error.message)
+              }
+              // console.log(error.config)
+            })
       }
       else if (votesSubmitted === 'true') {
         setSendPointsNote('done')
@@ -86,10 +98,18 @@ const Header = ({loadWeb3, disconnectWeb3, signer, address, addressDetails, wall
                                 </div>
                                 <div className='text-xs mt-[3px]'>Vote Credits</div>
                               </div>
-                              <div className={`flex items-center justify-center py-1 px-5 h-full bg-aquaDD hover:bg-aquaDD2 hover:text-indigoDD2 cursor-pointer min-w-[157px] ${(points > 0 || votesSubmitted === 'true') && 'grayscale brightness-150 hover:brightness-125'}`} onClick={submitPoints}>
+                              <div className={`flex items-center justify-center py-1 px-5 h-full bg-aquaDD hover:bg-aquaDD2 hover:text-indigoDD2 cursor-pointer min-w-[157px] 
+                                  ${points > 0 && 'grayscale brightness-150 hover:brightness-125'} 
+                                  ${votesSubmitted === 'true' && 'grayscale brightness-110 hover:brightness-110 hover:bg-aquaDD hover:text-indigoDD3'}`} 
+                                  onClick={submitPoints}>
                                 <div className='text-xl'>{votesSubmitted === 'sending' ? 'Sending' : votesSubmitted === 'true' ? 'Done' : 'Submit'}</div>
                               </div>
                             </div>
+                            { votesSubmitted !== 'true' && points === 0 && 
+                              <div className={'flex justify-center items-center px-1 text-center font-ibm font-bold text-[11px] text-indigoDD normal-case h-8 border-4 border-t-0 border-indigoDD'}>
+                                <span>By submitting you agree to&nbsp;<a target='_blank' rel='noreferrer' href='/terms' className='underline'>terms and conditions</a></span>
+                              </div>
+                            }
                             { sendPointsNote === 'all' && <div className={'note flex justify-center items-center pt-0.5 text-center font-ibm font-semibold text-sm text-[#181818] normal-case h-9'}>Distribute all your points to submit!</div>}
                             { sendPointsNote === 'done' && <div className={'note flex justify-center items-center pt-0.5 text-center font-ibm font-semibold text-sm text-[#181818] normal-case h-9'}>All your points were sent!</div>}
                           </div>

--- a/client/src/components/Phase2/index.js
+++ b/client/src/components/Phase2/index.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react'
 import Header from './Header'
 import Project from './Project'
 import ProjectPopup from './ProjectPopup'
+import ErrorPopup from '../ErrorPopup'
 import * as constants from '../../Constants'
 import { shuffle } from '../../Utils'
 import Countdown from 'react-countdown'
@@ -27,7 +28,8 @@ import squiggle2 from '../../assets/phase2/squiggle2.svg'
 // Phase2 Component
 // ------------------------------------------------------------------------------------------------------- //
 const Phase2 = ({loadWeb3, disconnectWeb3, signer, address, addressDetails, walletStatus, points, setPoints, votes, setVotes, setPhaseView}) => {
-  
+  const [errorPopupStatus, setErrorPopupStatus] = useState(false)
+
   const PICKS = 'https://dao-drops.herokuapp.com/posts/picks/'
 
   const [isVideoLoaded, setIsVideoLoaded] = useState(false)
@@ -35,7 +37,7 @@ const Phase2 = ({loadWeb3, disconnectWeb3, signer, address, addressDetails, wall
   const [popupDetails, setPopupDetails] = useState()
   const [projectsPicks, setProjectsPicks] = useState()
   const [votesSubmitted, setVotesSubmitted] = useState('false')
-  const phase2End = '2022-11-21T00:00:00.000+00:00'
+  const phase2End = '2023-02-28T00:00:00.000+00:00'
   // const phase2End = Date.now() + 10000
   
   useEffect(() => {
@@ -88,6 +90,7 @@ const Phase2 = ({loadWeb3, disconnectWeb3, signer, address, addressDetails, wall
             votes={votes}
             setVotesSubmitted={setVotesSubmitted}
             votesSubmitted={votesSubmitted}
+            setErrorPopupStatus={setErrorPopupStatus}
           />
 
           <div className={`flex items-start relative ${walletStatus === 'connected' ? 'pt-[5.55rem] 700px:pt-[6.9rem] 1000px:pt-[4.375rem] mt-0' : 'mt-8 700px:mt-12 1000px:mt-2'}`}>
@@ -108,7 +111,7 @@ const Phase2 = ({loadWeb3, disconnectWeb3, signer, address, addressDetails, wall
 
                   <div className='absolute top-[-5.5rem] left-[-6.7rem] 700px:-top-24 700px:-left-10 1000px:-left-1.5 z-20 scale-75 700px:scale-100'>
                     <div className='w-48 h-10 bg-white border-t-[6px] border-l-[6px] border-indigoDD text-lg font-ob font-bold uppercase flex justify-center items-center endsin-line phase2'>
-                      <div className='absolute pb-1 pl-1'>PHASE ENDS IN:</div>
+                      <div className='absolute pb-1 pl-1 uppercase text-[15px]'>allocation phase:</div>
                     </div>
 
                     <div className='w-[31rem] 700px:w-[32rem] h-[6.5rem] bg-white border-[7px] 700px:border-[6px] border-indigoDD font-obWide font-extrabold text-5xl flex justify-center items-center'>
@@ -138,7 +141,7 @@ const Phase2 = ({loadWeb3, disconnectWeb3, signer, address, addressDetails, wall
 
             <div className='mt-[10.5rem] relative right-0 hidden 1000px:block'>
               <div className='font-ob text-magentaDD text-xl 1000px:text-sm border-b border-magentaDD pb-4 w-full 1000px:w-[19rem]'>
-                Built by <a target='_blank' rel='noreferrer' href='https://www.dorg.tech' className='font-semibold hover:underline'>dOrg</a> and funded<br/>
+                Built by <a target='_blank' rel='noreferrer' href='https://www.dorg.tech' className='font-semibold hover:underline'>dOrg</a> and supported<br/>
                 by the <a target='_blank' rel='noreferrer' href='https://ethereum.foundation' className='font-semibold hover:underline'>Ethereum Foundation</a>
               </div>
 
@@ -149,10 +152,10 @@ const Phase2 = ({loadWeb3, disconnectWeb3, signer, address, addressDetails, wall
               </div>
             </div>
 
-            { projectsPicks &&
+            { projectsPicks && projectsPicks.length > 6 &&
               <>
-                <img className='absolute top-[83rem] left-[80%] z-0 hidden 1000px:block' src={dots3} alt='Dots' />
-                <img className='absolute top-[94rem] left-[10%] z-0 hidden 1000px:block' src={squiggle2} alt='Squiggle' />
+                <img className={`absolute ${projectsPicks.length > 18 ? 'top-[83rem]' : 'top-[49rem]'} left-[80%] z-0 hidden 1000px:block`} src={dots3} alt='Dots' />
+                <img className={`absolute ${projectsPicks.length > 18 ? 'top-[90rem]' : 'top-[55rem]'} left-[10%] z-0 hidden 1000px:block`} src={squiggle2} alt='Squiggle' />
               </>
             }
           </div>
@@ -173,7 +176,7 @@ const Phase2 = ({loadWeb3, disconnectWeb3, signer, address, addressDetails, wall
 
                 <div className='mb-20 w-full relative block 1000px:hidden'>
                   <div className='font-ob text-magentaDD text-xl border-b border-magentaDD pb-4 w-full '>
-                    Built by <a target='_blank' rel='noreferrer' href='https://www.dorg.tech' className='font-semibold hover:underline'>dOrg</a> and funded<br/>
+                    Built by <a target='_blank' rel='noreferrer' href='https://www.dorg.tech' className='font-semibold hover:underline'>dOrg</a> and supported<br/>
                     by the <a target='_blank' rel='noreferrer' href='https://ethereum.foundation' className='font-semibold hover:underline'>Ethereum Foundation</a>
                   </div>
 
@@ -256,7 +259,7 @@ const Phase2 = ({loadWeb3, disconnectWeb3, signer, address, addressDetails, wall
 
       <footer className='w-full h-24 px-[4%] flex justify-between items-center bg-footerColor'>
         <div className='font-ob text-magentaDD text-base 600px:text-lg 1000px:w-1/3'>
-          Built by <a target='_blank' rel='noreferrer' href='https://www.dorg.tech' className='font-semibold hover:underline'>dOrg</a> and funded<br/>
+          Built by <a target='_blank' rel='noreferrer' href='https://www.dorg.tech' className='font-semibold hover:underline'>dOrg</a> and supported<br/>
           by the <a target='_blank' rel='noreferrer' href='https://ethereum.foundation' className='font-semibold hover:underline'>Ethereum Foundation</a>
         </div>
 
@@ -280,6 +283,7 @@ const Phase2 = ({loadWeb3, disconnectWeb3, signer, address, addressDetails, wall
         votesSubmitted={votesSubmitted} 
       />
 
+      {errorPopupStatus && <ErrorPopup setErrorPopupStatus={setErrorPopupStatus} />}
     </>
   )}
 

--- a/client/src/components/Phase3/Project.js
+++ b/client/src/components/Phase3/Project.js
@@ -1,23 +1,28 @@
 import React from 'react'
+import { numberWithCommas } from '../../Utils'
 import Jazzicon, { jsNumberForAddress } from 'react-jazzicon'
 import heart from '../../assets/icons/heart.svg'
 
 
 // Project Component (Phase3)
 // ------------------------------------------------------------------------------------------------------- //
-const Project = ({index, id, name, desc, website, paddress, icon, setPopupStatus, setPopupDetails, points, votedProjects}) => {
+const Project = ({index, id, name, desc, website, paddress, icon, points, usdcAmount, setPopupStatus, setPopupDetails, votedProjects, walletStatus, pointsSum}) => {
     const colors = ['p-orange', 'p-green', 'p-pink', 'p-blue']
     const colorsPattern = [0,1,2,3,1,2,3,0,2,3,0,1,3,0,1,2]
     const color = colors[colorsPattern[index%16]]
+    const voted = votedProjects && votedProjects.includes(id) && walletStatus === 'connected'
+    const usd = (points / pointsSum) * 250000
+    // const usd = usdcAmount
 
     return (
       <div className={`w-52 h-48 700px:w-72 700px:h-64 rounded-[1.75rem] p-2 px-5 700px:p-4 700px:px-7 relative ${color} `}>
-        <div className={`font-ob font-extrabold text-[1.4rem] 700px:text-[32px] leading-8 700px:leading-10 pt-1 ellipsis h-[68px] 700px:h-[84px] break-words ${ votedProjects && votedProjects.includes(id) && 'w-[74%] 700px:w-[79%]' }`}>{name}</div>
+        <div className={`font-ob font-extrabold text-[1.4rem] 700px:text-[32px] leading-8 700px:leading-10 pt-1 ellipsis h-[68px] 700px:h-[84px] break-words ${ voted && 'w-[74%] 700px:w-[79%]' }`}>{name}</div>
         <div className='mt-3 700px:mt-4 z-10 details-button' onClick={ () => { setPopupStatus('visible'); setPopupDetails({ name: name, message: desc, link: website, paddress: paddress, image: icon, points: points }); } }>view details</div>
   
-        <div className='flex flex-col mt-2 700px:mt-5'>
-          <div className={`font-obWide font-extrabold pb-0.5 700px:pb-1 h-[42px] 700px:h-[52px] flex items-end ${points > 999 ? 'text-[28px] leading-9 700px:text-4xl' : 'text-4xl 700px:text-5xl' }`}>{points || '0'}</div>
-          <div className='font-bold uppercase text-[0.6rem] 700px:text-[0.8rem]'>points Received</div>
+        <div className='flex flex-col mt-1.5 700px:mt-4'>
+          <div className={`font-obWide font-extrabold pb-0.5 700px:pb-1 h-[34px] 700px:h-[44px] flex items-end ${points > 999 ? 'text-[28px] leading-7 700px:text-4xl' : 'text-[32px] leading-8 700px:leading-[43px] 700px:text-[45px]' }`}>{points || '0'}</div>
+          <div className='font-bold uppercase text-[0.6rem] 700px:text-[0.72rem]'>points Received</div>
+          <div className='font-bold uppercase text-indigoDD4 text-[0.6rem] 700px:text-[0.82rem]'>${numberWithCommas(usd.toFixed(0))} - USDC</div>
         </div>
   
         <div className='absolute bottom-0 right-0 mr-3 mb-3 700px:mr-4 700px:mb-4 rounded-full '>
@@ -30,7 +35,7 @@ const Project = ({index, id, name, desc, website, paddress, icon, setPopupStatus
           }
           </div>
   
-        { votedProjects && votedProjects.includes(id) &&
+        {  voted &&
           <div className='absolute top-2 700px:top-4 right-0 scale-75 700px:scale-100'>
             <img className='mr-3 mb-3 700px:mr-4 700px:mb-4 w-[55px] 700px:w-auto' src={heart} alt='voted' />
             <div className='absolute top-[14px] left-2 text-[10.5px] font-bold'>VOTED</div>

--- a/client/src/components/Phase3/index.js
+++ b/client/src/components/Phase3/index.js
@@ -30,12 +30,14 @@ const Phase3 = ({loadWeb3, disconnectWeb3, address, addressDetails, walletStatus
   const [projectsPicks, setProjectsPicks] = useState()
   const [popupDetails, setPopupDetails] = useState()
   const [votedProjects, setVotedProjects] = useState()
+  const [pointsSum, setPointsSum] = useState(0)
 
   useEffect(() => {
     axios.get(PICKS)
       .then(r => {
         let sortedProjects = r.data.sort((a,b) => b.currentScore - a.currentScore)
         setProjectsPicks(sortedProjects)
+        setPointsSum(sortedProjects.reduce((a, b) => a + b.currentScore, 0))
       })
       .catch(e => console.error(e))
   }, [])
@@ -122,7 +124,7 @@ const Phase3 = ({loadWeb3, disconnectWeb3, address, addressDetails, walletStatus
           <div className='flex pb-8 1000px:p-0 1000px:ml-20 justify-between relative'>
             <div className='mt-8 relative right-0 hidden 1000px:block'>
               <div className='font-ob text-magentaDD text-xl 1000px:text-sm border-b border-magentaDD pb-4 w-full 1000px:w-[19rem]'>
-                Built by <a target='_blank' rel='noreferrer' href='https://www.dorg.tech' className='font-semibold hover:underline'>dOrg</a> and funded<br/>
+                Built by <a target='_blank' rel='noreferrer' href='https://www.dorg.tech' className='font-semibold hover:underline'>dOrg</a> and supported<br/>
                 by the <a target='_blank' rel='noreferrer' href='https://ethereum.foundation' className='font-semibold hover:underline'>Ethereum Foundation</a>
               </div>
 
@@ -133,18 +135,18 @@ const Phase3 = ({loadWeb3, disconnectWeb3, address, addressDetails, walletStatus
               </div>
             </div>
 
-            { projectsPicks &&
-            <>
-              <img className='absolute top-[83rem] left-[80%] z-0 hidden 1000px:block' src={dots3} alt='Dots' />
-              <img className='absolute top-[90rem] left-[10%] z-0 hidden 1000px:block' src={squiggle2} alt='Squiggle' />
-            </>
+            { projectsPicks && projectsPicks.length > 6 &&
+              <>
+                <img className={`absolute ${projectsPicks.length > 18 ? 'top-[83rem]' : 'top-[49rem]'} left-[80%] z-0 hidden 1000px:block`} src={dots3} alt='Dots' />
+                <img className={`absolute ${projectsPicks.length > 18 ? 'top-[90rem]' : 'top-[55rem]'} left-[10%] z-0 hidden 1000px:block`} src={squiggle2} alt='Squiggle' />
+              </>
             }
           </div>
           
 
           <div className='mb-20 w-full relative block 1000px:hidden'>
             <div className='font-ob text-magentaDD text-xl border-b border-magentaDD pb-4 w-full '>
-              Built by <a target='_blank' rel='noreferrer' href='https://www.dorg.tech' className='font-semibold hover:underline'>dOrg</a> and funded<br/>
+              Built by <a target='_blank' rel='noreferrer' href='https://www.dorg.tech' className='font-semibold hover:underline'>dOrg</a> and supported<br/>
               by the <a target='_blank' rel='noreferrer' href='https://ethereum.foundation' className='font-semibold hover:underline'>Ethereum Foundation</a>
             </div>
 
@@ -156,7 +158,7 @@ const Phase3 = ({loadWeb3, disconnectWeb3, address, addressDetails, walletStatus
 
           </div>
 
-          <a href='#leaderboard' className='button1-down mx-auto self-center 1000px:mx-0 1000px:self-start text-3xl w-[26rem] block 1000px:hidden'>Check Results</a>
+          <a href='#leaderboard' className='button1-down mx-auto self-center 1000px:mx-0 1000px:self-start text-2xl w-[21rem] 600px:text-3xl 600px:w-[26rem] block 1000px:hidden'>Check Results</a>
           <div className='mt-32 mb-8 mx-auto w-72 h-[6px] bg-[#ACBBC2] rounded-full opacity-40 1000px:hidden'/>
   
           <div id='leaderboard' className='mt-12 1000px:mt-32 mb-20 z-10 text-center m-auto'>
@@ -179,10 +181,13 @@ const Phase3 = ({loadWeb3, disconnectWeb3, address, addressDetails, walletStatus
                   website={project.website}
                   paddress={project.address}
                   icon={project.icon}
+                  points={project.currentScore}
+                  usdcAmount={project.usdcAmount}
                   setPopupStatus={setPopupStatus}
                   setPopupDetails={setPopupDetails}
-                  points={project.currentScore}
                   votedProjects={votedProjects}
+                  walletStatus={walletStatus}
+                  pointsSum={pointsSum}
                 />
               )
             }
@@ -193,7 +198,7 @@ const Phase3 = ({loadWeb3, disconnectWeb3, address, addressDetails, walletStatus
 
       <footer className='w-full h-24 px-[4%] flex justify-between items-center bg-footerColor'>
         <div className='font-ob text-magentaDD text-base 600px:text-lg 1000px:w-1/3'>
-          Built by <a target='_blank' rel='noreferrer' href='https://www.dorg.tech' className='font-semibold hover:underline'>dOrg</a> and funded<br/>
+          Built by <a target='_blank' rel='noreferrer' href='https://www.dorg.tech' className='font-semibold hover:underline'>dOrg</a> and supported<br/>
           by the <a target='_blank' rel='noreferrer' href='https://ethereum.foundation' className='font-semibold hover:underline'>Ethereum Foundation</a>
         </div>
 

--- a/client/src/components/Terms/index.js
+++ b/client/src/components/Terms/index.js
@@ -1,0 +1,66 @@
+import React, { useState, useEffect, useRef } from 'react'
+import * as constants from '../../Constants'
+import Countdown from 'react-countdown'
+import TermsText from './text'
+
+import logo from '../../assets/logos/logo.svg'
+import dropsVideo from '../../assets/video/drops.mp4'
+import dropsVideoOGG from '../../assets/video/drops.ogg'
+import dropsVideoWEBM from '../../assets/video/drops.webm'
+import dropsThumbnail from '../../assets/video/drops-thumbnail.jpg'
+import bubble from '../../assets/particles/bubble.png'
+import squiggle from '../../assets/phase1/squiggle.svg'
+import dots from '../../assets/phase1/dots.svg'
+import smallDots from '../../assets/phase1/dots-small.svg'
+import aquaBox from '../../assets/phase1/aqua-box.svg'
+import twitter from '../../assets/icons/twitter.svg'
+
+
+// Terms & Conditions Component
+// ------------------------------------------------------------------------------------------------------- //
+const Terms = () => {
+  
+  return (
+    <>
+      <div className='phase1-bg-mobile 1000px:phase1-bg px-[5%] 1000px:px-[20%] pt-9'>
+      <a className='font-ob font-semibold text-magentaDD tracking-[4px] text-xl relative flex justify-end 1200px:right-[-8.5%] -top-3 z-20 hover:text-magentaDD4' href={constants.FAQ} target='_blank' rel='noreferrer'>FAQ</a>
+          <div className='flex items-start relative'>
+              <a href='https://daodrops.io' className='min-w-[49px] min-h-[408]'>
+								<img src={logo} alt='DAO Drops Logo' className='z-10 w-[49px] h-[408]'/>
+							</a>
+
+              <div className='flex flex-col'>
+                <div className='ml-6 1000px:ml-10 my-10 z-10'>
+                  <h3 className='text-4xl'>Terms & Conditions</h3>
+                  <div className='py-10 max-w-[370px] 550px:max-w-max'>
+										<TermsText />
+									</div>
+                </div>
+              </div>
+
+
+          </div>
+
+      </div>
+
+
+
+			<footer className='w-full h-24 px-[4%] flex justify-between items-center bg-footerColor'>
+					<div className='font-ob text-magentaDD text-base 600px:text-lg 1000px:w-1/3'>
+            Built by <a target='_blank' rel='noreferrer' href='https://www.dorg.tech' className='font-semibold hover:underline'>dOrg</a> and supported<br/>
+            by the <a target='_blank' rel='noreferrer' href='https://ethereum.foundation' className='font-semibold hover:underline'>Ethereum Foundation</a>
+            </div>
+
+            <a className='font-ob font-semibold text-magentaDD tracking-[4px] text-xl 1000px:w-1/3 text-center hover:text-magentaDD4' href={constants.FAQ} target='_blank' rel='noreferrer'>FAQ</a>
+
+            <div className='1000px:w-1/3 text-right'>
+            <a target='_blank' rel='noreferrer' href={constants.Twitter}>
+                <img className='inline scale-150 hover:scale-[155%]' src={twitter} alt='Twitter' />
+            </a>
+					</div>
+			</footer>
+    </>
+  )}
+// ------------------------------------------------------------------------------------------------------- //
+
+export default Terms;

--- a/client/src/components/Terms/text.js
+++ b/client/src/components/Terms/text.js
@@ -1,0 +1,187 @@
+// Terms & Conditions Text Component
+// ------------------------------------------------------------------------------------------------------- //
+const TermsText = () => 
+    <>
+      <h4 className='pt-8 pb-2 font-bold'>1. ACCEPTANCE OF TERMS</h4>
+      <subtitle1 className='leading-7 text-justify'>
+        dOrg, LLC, a Vermont based limited liability corporation (“dOrg”) is a blockchain-based decentralized autonomous organization (“DAO”) that provides software developmental services. “Tasks” means any service a Site participant requests or performs. The dOrg website and the DAO DROP website (<a className='underline' href='https://dorg.tech' target='_blank' rel='noreferrer'>https://dorg.tech</a> and <a className='underline' href='https://daodrops.io' target='_blank' rel='noreferrer'>https://daodrops.io</a> together known as the “Site”, “Site Services”, “Platform”) serves as a registration portal and an overview of dOrg’s services including information on DAO DROPS. The site also includes text, images, audio, code and other materials or third party information. The Site and any other features, tools, materials, or services offered from time to time by dOrg, including without limitation the Service Offerings, is referred to here as the “Service”. Please read these Terms of Use (the “Terms” or “Terms of Use”) carefully, including the Privacy Policy (“Privacy Policy” found at <a className='underline' href='https://www.dorg.tech/#/privacy-policy' target='_blank' rel='noreferrer'>https://www.dorg.tech/#/privacy-policy</a> ) before using the Service. By using or otherwise accessing the Services, or clicking to accept or agree to these Terms where that option is made available, you (1) accept and agree to these Terms, (2) consent to the collection, use, disclosure and other handling of information as described in our Privacy Policy and (3) any additional terms, rules and conditions of participation issued by dOrg from time to time.&nbsp;
+				<span className='font-semibold'>IF YOU DO NOT AGREE TO THE TERMS, THEN YOU MAY NOT ACCESS OR USE THE SERVICES.</span>
+      </subtitle1>
+
+			<h4 className='pt-8 pb-2 font-bold'>2. MODIFICATIONS OF TERMS OF USE</h4>
+      <subtitle1 className='leading-7 text-justify'>
+				Except for Section 21, providing for binding arbitration and waiver of class action rights, dOrg reserves the right, at its sole discretion, to modify or replace the Terms of Use at any time. The most current version of these Terms will be posted on our Site. You shall be responsible for reviewing and becoming familiar with any such modifications. Use of the Services by you after any modification to the Terms constitutes your acceptance of the Terms of Use as modified.
+			</subtitle1>
+
+			<h4 className='pt-8 pb-2 font-bold'>3. ELIGIBILITY</h4>
+      <subtitle1 className='leading-7 text-justify'>
+				You represent and warrant that you: (a) are of legal age to form a binding contract; (b) have not previously been suspended or removed from using our Services; and (c) have full power and authority to enter into this agreement 	and in doing so will not violate any other agreement to which you are a party. If you are registering to use the Services on behalf of a legal entity, you further represent and warrant that (d) such legal entity is duly organized and validly existing under the applicable laws of the jurisdiction of its organization, and (e) you are duly authorized by such legal entity to act on its behalf.
+			</subtitle1>
+
+			<h4 className='pt-8 pb-2 font-bold'>4. ROLE OF dORG</h4>
+      <subtitle1 className='leading-7 text-justify'>
+				You expressly acknowledge, agree, and understand that: the Site is merely a platform through which Users can inquire on Services and offerings by dOrg, including the DAO DROPs initiative.
+			</subtitle1>
+
+			<h4 className='pt-8 pb-2 font-bold'>5. INDEPENDENT CONTRACTORS</h4>
+      <subtitle1 className='leading-7 text-justify'>
+				Applicants perform services for DAO DROPs initiative in their personal capacity as an independent contractor and not as an employee dOrg or the DAO DROPs initiative. As a Applicant and User, you agree that: (a) you are responsible for and will comply with all applicable laws and registration requirements, including those applicable to independent contractors and maximum working hours regulations; (b) these Terms do not create an association, joint venture, partnership, franchise, or employer/employee relationship between you and DAO DROPs initiative, or you and dOrg; (iii) you will not represent yourself as an employee or agent of DAO DROPs initiative or dOrg; (iv) you will not be entitled to any of the benefits that DAO DROPs initiative or dOrg may make available to its employees, such as vacation pay, sick leave, and insurance programs, including group health insurance or retirement benefits; and (v) you are not eligible to recover worker's compensation benefits in the event of injury. As an independent contractor, Applicant/User is free at all times to provide services to persons or businesses other than DAO DROPs initiative, including any competitor of DAO DROPs initiative. Applicant/User does not have authority to enter into written or oral (whether implied or express) contracts on behalf of DAO DROPs initiative or dOrg. 
+			</subtitle1>
+
+			<h4 className='pt-8 pb-2 font-bold'>6. DAO DROPS GRANTS</h4>
+      <subtitle1 className='leading-7 text-justify'>
+				As used herein, a “Grant” means, as applicable, the unilateral contractual provisions created by Applicant/User that govern the Grant terms that have already been performed by Applicant/User for a particular purpose as posted to the Site and which will typically include a description of the task or services that have been completed. 
+			</subtitle1>
+
+			<h4 className='pt-8 pb-2 font-bold'>7. PAYMENT</h4>
+      <subtitle1 className='leading-7 text-justify'>
+				If a User is chosen for the DAO DROPs initiative, each User must provide its Ethereum wallet address. Payment to Applicant/User will occur shortly after selection by dOrg along with a valid Ethereum wallet address. Users selected into the DAO DROPs initiative is at the sole discretion of dOrg.
+			</subtitle1>
+
+			<h4 className='pt-8 pb-2 font-bold'>8. RESTRICTIONS ON USE</h4>
+      <subtitle1 className='leading-7 text-justify'>
+				Unless otherwise expressly authorized in these Terms of Use or on the Site, you may not take any action to interfere with the Site or any other user’s use of the Site or decompile, reverse engineer or disassemble any content or other products or processes accessible through the Site, nor insert any code or product or manipulate the content in any way that affects any User’s experience. While using the Site you are required to comply with all applicable statutes, orders, regulations, rules, and other laws. In addition, we expect users of the Website to respect the rights and dignity of others. Your use of the Site is conditioned on your compliance with the rules of conduct set forth in this Terms of Use.
+			</subtitle1>
+
+			<h4 className='pt-8 pb-2 font-bold'>9. WARRANTY DISCLAIMER</h4>
+      <subtitle1 className='leading-7 text-justify'>
+				You expressly understand and agree that your use of the Site Services or platform is at your sole risk. The service is provided on an "AS IS" and "as available" basis, without warranties of any kind, either express or implied, including, without limitation, implied warranties of merchantability, fitness for a particular purpose or non-infringement. You release dOrg from all liability for content you acquired or failed to acquire through the Site Services.
+			</subtitle1>
+
+			<h4 className='pt-8 pb-2 font-bold'>10. SOPHISTICATION AND RISK OF CRYPTOGRAPHIC SYSTEMS</h4>
+      <subtitle1 className='leading-7 text-justify'>
+				By utilizing the Site Services or platform in any way, you represent that you understand the inherent risks associated with cryptographic systems; and warrant that you have an understanding of the usage and intricacies of public/private key cryptography, native cryptographic tokens, like Ether (ETH), smart contract based tokens such as those that follow the Ethereum Token Standard (<a className='underline' href='https://github.com/ethereum/EIPs/issues/20' target='_blank' rel='noreferrer'>https://github.com/ethereum/EIPs/issues/20</a>), and blockchain-based software systems.
+			</subtitle1>
+
+			<h4 className='pt-8 pb-2 font-bold'>11. RISK OF ERRORS, BUGS, AND DOWNTIME</h4>
+      <subtitle1 className='leading-7 text-justify'>
+				You acknowledge and accept that the Services and platform (1) may contain bugs, errors and defects, (2) may function improperly or be subject to periods of downtime and unavailability, (3) may result in total or partial loss or corruption of data used in the Services, and (4) may be modified at any time, including through the release of subsequent versions, all with or without notice.
+			</subtitle1>
+
+			<h4 className='pt-8 pb-2 font-bold'>12. INDEMNITY</h4>
+      <subtitle1 className='leading-7 text-justify'>
+				You agree, to the fullest extent permitted by applicable law, to release and to indemnify, defend and hold harmless dOrg and its parents, subsidiaries, affiliates and agencies, as well as the officers, directors, employees, shareholders and representatives of any of the foregoing entities, from and against any and all losses, liabilities, expenses, damages, costs (including attorneys’ fees and court costs) claims or actions of any kind whatsoever arising or resulting from: (a) your use of the Service, (b) your violation of these Terms of Use, (c) any of your acts or omissions that implicate publicity rights, defamation, invasion of privacy, confidentiality, intellectual property rights or other property rights, (d) any misrepresentation by you and (e) any disputes or issues between you and any third party. dOrg reserves the right, at its own expense, to assume exclusive defense and control of any matter otherwise subject to indemnification by you and, in such case, you agree to cooperate with dOrg in the defense of such matter.
+			</subtitle1>
+
+			<h4 className='pt-8 pb-2 font-bold'>13. LIMITATION ON LIABILITY</h4>
+      <subtitle1 className='leading-7 text-justify'>
+				YOU ACKNOWLEDGE AND AGREE THAT YOU ASSUME FULL RESPONSIBILITY FOR YOUR USE OF THE SITE AND SERVICE. YOU ACKNOWLEDGE AND AGREE THAT ANY INFORMATION YOU SEND OR RECEIVE DURING YOUR USE OF THE SITE AND SERVICE MAY NOT BE SECURE AND MAY BE INTERCEPTED OR LATER ACQUIRED BY UNAUTHORIZED PARTIES. YOU ACKNOWLEDGE AND AGREE THAT YOUR USE OF THE SITE AND SERVICE IS AT YOUR OWN RISK. RECOGNIZING SUCH, YOU UNDERSTAND AND AGREE THAT, TO THE FULLEST EXTENT PERMITTED BY APPLICABLE LAW, NEITHER dORG NOR ITS PARENTS, SUBSIDIARIES, AFFILIATES AND AGENCIES, AS WELL AS THE OFFICERS, DIRECTORS, EMPLOYEES, SHAREHOLDERS OR REPRESENTATIVES OF ANY OF THE FOREGOING ENTITIES, OR ITS SUPPLIERS OR LICENSORS WILL BE LIABLE TO YOU FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, PUNITIVE, EXEMPLARY OR OTHER DAMAGES OF ANY KIND, INCLUDING WITHOUT LIMITATION DAMAGES FOR LOSS OF PROFITS, GOODWILL, USE, DATA OR OTHER TANGIBLE OR INTANGIBLE LOSSES OR ANY OTHER DAMAGES BASED ON CONTRACT, TORT (INCLUDING, IN JURISDICTIONS WHERE PERMITTED, NEGLIGENCE AND GROSS NEGLIGENCE), STRICT LIABILITY OR ANY OTHER THEORY (EVEN IF DORG HAD BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES), RESULTING FROM THE SITE OR SERVICE; THE USE OR THE INABILITY TO USE THE SITE OR SERVICE; UNAUTHORIZED ACCESS TO OR ALTERATION OF YOUR TRANSMISSIONS OR DATA; STATEMENTS OR CONDUCT OF ANY THIRD PARTY ON THE SITE OR SERVICE; ANY ACTIONS WE TAKE OR FAIL TO TAKE AS A RESULT OF COMMUNICATIONS YOU SEND TO US; HUMAN ERRORS; TECHNICAL MALFUNCTIONS; FAILURES, INCLUDING PUBLIC UTILITY OR TELEPHONE OUTAGES; OMISSIONS, INTERRUPTIONS, LATENCY, DELETIONS OR DEFECTS OF ANY DEVICE OR NETWORK, PROVIDERS, OR SOFTWARE (INCLUDING, BUT NOT LIMITED TO, THOSE THAT DO NOT PERMIT PARTICIPATION IN THE SERVICE); ANY INJURY OR DAMAGE TO COMPUTER EQUIPMENT; INABILITY TO FULLY ACCESS THE SITE OR SERVICE OR ANY OTHER WEBSITE; THEFT, TAMPERING, DESTRUCTION, OR UNAUTHORIZED ACCESS TO, IMAGES OR OTHER CONTENT OF ANY KIND; DATA THAT IS PROCESSED LATE OR INCORRECTLY OR IS INCOMPLETE OR LOST; TYPOGRAPHICAL, PRINTING OR OTHER ERRORS, OR ANY COMBINATION THEREOF; OR ANY OTHER MATTER RELATING TO THE SITE OR SERVICE.
+				<br/><br/>
+				SOME JURISDICTIONS DO NOT ALLOW THE EXCLUSION OF CERTAIN WARRANTIES OR THE LIMITATION OR EXCLUSION OF LIABILITY FOR INCIDENTAL OR CONSEQUENTIAL DAMAGES. ACCORDINGLY, SOME OF THE ABOVE LIMITATIONS MAY NOT APPLY TO YOU.
+			</subtitle1>
+
+			<h4 className='pt-8 pb-2 font-bold'>14. LICENSES</h4>
+      <subtitle1 className='leading-7 text-justify'>
+				14.1. Site License Subject to and conditioned on your compliance with these Terms of Use, dOrg grants you a limited, non-exclusive, non-transferable, non-sublicensable license to access and make personal and non-commercial use of the Service and Site. This license does not include any resale or commercial use of the Service or any derivative use of the Service. All rights not expressly granted to you in these Terms of Use are reserved and retained by dOrg or its licensors. The dOrg Service may not be reproduced, duplicated, copied, sold, resold, visited, or otherwise exploited for any commercial purpose without express written consent of dOrg. You may not frame or utilize framing techniques to enclose any trademark, logo, or other proprietary information (including images, text, page layout, or form) of dOrg without express written consent. You may not misuse the Services. You may use the Services only as permitted by law. The licenses granted by dOrg terminate if you do not comply with these Terms of Use. dOrg retains all right, title, and interest in and to all Intellectual Property Rights in and to the Site and the Site Services.
+				<br/><br/>
+				14.2. User Content License When you post or submit any data, feedback, content, text, photographs, images, or other information to any part of the Site or provide to dOrg (referred to as “User Content”), you represent and warrant that you have the right, power, and authority to post that User Content and grant the licenses specified below. You further represent and warrant that by posting or providing such User Content you will not violate third-party rights of any kind, including, without limitation, any Intellectual Property Rights, rights of publicity, or privacy rights. To the extent your User Content may be copyrightable, you represent, warrant, and covenant that you are the owner of all the copyright rights to such User Content and that dOrg may exercise the rights to your User Content granted under the Terms of Use without any liability or obligation for any payment. You retain all ownership rights in any User Content you post on the Site, Site Services, or any of dOrg’s platforms. To the extent permitted by applicable law, you also grant to dOrg and our successors and affiliates a royalty-free, sub-licensable, transferable, perpetual, irrevocable, non-exclusive, worldwide license to use, reproduce, modify, publish, list information regarding, edit, translate, distribute, publicly perform, publicly display, and make derivative works of all such User Content and your name, voice, and/or likeness as contained in your User Content, in whole or in part, and in any form, media, or technology, whether now known or hereafter developed, for use in connection with the Site and dOrg (and our successors’ and affiliates’) business, including, without limitation, for promoting and redistributing part or all of the Site (and derivative works thereof) in any media formats and through any media channels. You also hereby grant each User a non-exclusive license to access your User Content through the Site and to use, reproduce, distribute, display, and perform such User Content to the extent permitted through the normal functionality of the Site and subject to all applicable confidentiality and other provisions of this Agreement, our Privacy Policy, and applicable law. The licenses to User Content granted by you in this Agreement will terminate within a commercially reasonable time after you remove or delete your User Content from the Site, except that you grant dOrg and our successors and affiliates the irrevocable and perpetual license to retain and use, but not publicly display or distribute, server or archival copies of all User Content that you have removed or deleted to the extent permitted by applicable law.
+			</subtitle1>
+
+      <h4 className='pt-8 pb-2 font-bold'>15. TERMINATION AND SUSPENSION</h4>
+      <subtitle1 className='leading-7 text-justify'>
+       dOrg may terminate or suspend all or part of the Service without prior notice or liability if you breach any of the terms or conditions of the Terms. We may, in our sole discretion and without liability to you, with or without prior notice and at any time, modify or discontinue, temporarily or permanently, any portion of our Services.
+       <br/><br/>
+       The following provisions of the Terms survive any termination of these Terms: INDEMNITY; WARRANTY DISCLAIMERS; LIMITATION ON LIABILITY; OUR PROPRIETARY RIGHTS; TERMINATION AND SUSPENSION; NO THIRD PARTY BENEFICIARIES; BINDING ARBITRATION AND CLASS ACTION WAIVER; GENERAL INFORMATION.
+      </subtitle1>
+
+      <h4 className='pt-8 pb-2 font-bold'>16. NO THIRD PARTY BENEFICIARIES</h4>
+      <subtitle1 className='leading-7 text-justify'>
+       You agree that, except as otherwise expressly provided in these Terms, there shall be no third party beneficiaries to the Terms. The Terms of Use will not be construed as creating or implying any relationship of agency, franchise, partnership, or joint venture between Users and dOrg, except and solely to the extent expressly stated in this Agreement.
+      </subtitle1>
+
+      <h4 className='pt-8 pb-2 font-bold'>17. NOTICE AND PROCEDURE FOR MAKING COPYRIGHT INFRINGEMENT CLAIMS</h4>
+      <subtitle1 className='leading-7 text-justify'>
+      If you believe that your copyright or the copyright of a person on whose behalf you are authorized to act has been infringed, please provide dOrg a written notice containing the following information:
+      <br/><br/>
+      (1)an electronic or physical signature of the person authorized to act on behalf of the owner of the copyright or other intellectual property interest;<br/>
+      (2)a description of the copyrighted work or other intellectual property that you claim has been infringed;<br/>
+      (3)a description of where the material that you claim is infringing is located on the Service.<br/>
+      dOrg can be reached at:<br/>
+      Email: <a href="mailto:legal@dorg.tech">legal@dorg.tech</a><br/>
+      Subject Line: Copyright Notification
+      </subtitle1>
+
+      <h4 className='pt-8 pb-2 font-bold'>18. BINDING ARBITRATION AND CLASS ACTION WAIVER</h4>
+      <subtitle1 className='leading-7 text-justify'>
+        PLEASE READ THIS SECTION CAREFULLY – IT MAY SIGNIFICANTLY AFFECT YOUR LEGAL RIGHTS, INCLUDING YOUR RIGHT TO FILE A LAWSUIT IN COURT
+      </subtitle1>
+
+      <h4 className='pt-8 pb-2 font-bold'>19. Initial Dispute Resolution</h4>
+      <subtitle1 className='leading-7 text-justify'>
+       The parties shall use their best efforts to engage directly to settle any dispute, claim, question, or disagreement and engage in good faith negotiations which shall be a condition to either party initiating a lawsuit or arbitration.
+      </subtitle1>
+
+      <h4 className='pt-8 pb-2 font-bold'>20. Binding Arbitration</h4>
+      <subtitle1 className='leading-7 text-justify'>
+        If the parties do not reach an agreed upon solution within a period of 30 days from the time informal dispute resolution under the Initial Dispute Resolution provision begins, then either party may initiate binding arbitration as the sole means to resolve claims, subject to the terms set forth below. Specifically, all claims arising out of or relating to these Terms (including their formation, performance and breach), the parties’ relationship with each other and/or your use of the Service shall be finally settled by binding arbitration administered by the American Arbitration Association in accordance with the provisions of its Commercial Arbitration Rules and the supplementary procedures for consumer related disputes of the American Arbitration Association (the “AAA”), excluding any rules or procedures governing or permitting class actions. The arbitrator, and not any federal, state or local court or agency, shall have exclusive authority to resolve all disputes arising out of or relating to the interpretation, applicability, enforceability or formation of these Terms, including, but not limited to any claim that all or any part of these Terms are void or voidable, or whether a claim is subject to arbitration. The arbitrator shall be empowered to grant whatever relief would be available in a court under law or in equity. The arbitrator’s award shall be written, and binding on the parties and may be entered as a judgment in any court of competent jurisdiction. The parties understand that, absent this mandatory provision, they would have the right to sue in court and have a jury trial. They further understand that, in some instances, the costs of arbitration could exceed the costs of litigation and the right to discovery may be more limited in arbitration than in court.
+      </subtitle1>
+
+      <h4 className='pt-8 pb-2 font-bold'>21. Location</h4>
+      <subtitle1 className='leading-7 text-justify'>
+        Binding arbitration shall take place in Florida. You agree to submit to the personal jurisdiction of any federal or state court in Vermont, in order to compel arbitration, to stay proceedings pending arbitration, or to confirm, modify, vacate or enter judgment on the award entered by the arbitrator.
+      </subtitle1>
+
+      <h4 className='pt-8 pb-2 font-bold'>22. Class Action Waiver</h4>
+      <subtitle1 className='leading-7 text-justify'>
+        The parties further agree that any arbitration or other permitted action shall be conducted in their individual capacities only and not as a class action or other representative action, and the parties expressly waive their right to file a class action or seek relief on a class basis. YOU AND DORG AGREE THAT EACH MAY BRING CLAIMS AGAINST THE OTHER ONLY IN YOUR OR ITS INDIVIDUAL CAPACITY, AND NOT AS A PLAINTIFF OR CLASS MEMBER IN ANY PURPORTED CLASS OR REPRESENTATIVE PROCEEDING. If any court or arbitrator determines that the class action waiver set forth in this paragraph is void or unenforceable for any reason or that an arbitration can proceed on a class basis, then the arbitration provision set forth above shall be deemed null and void in its entirety and the parties shall be deemed to have not agreed to arbitrate disputes.
+      </subtitle1>
+
+      <h4 className='pt-8 pb-2 font-bold'>23. Exception - Litigation of Intellectual Property and Small Claims Court Claims</h4>
+      <subtitle1 className='leading-7 text-justify'>
+        Notwithstanding the parties' decision to resolve all disputes through arbitration, either party may bring an action in state or federal court to protect its intellectual property rights (“intellectual property rights” means patents, copyrights, moral rights, trademarks, and trade secrets, but not privacy or publicity rights). Either party may also seek relief in a small claims court for disputes or claims within the scope of that court’s jurisdiction.
+      </subtitle1>
+
+      <h4 className='pt-8 pb-2 font-bold'>24. Changes to this Section</h4>
+      <subtitle1 className='leading-7 text-justify'>
+        dOrg will provide 60-days’ notice of any changes to this Section. Changes will become effective on the 60th day, and will apply prospectively only to any claims arising after the 60th day. For any dispute not subject to arbitration you and dOrg agree to submit to the personal and exclusive jurisdiction of and venue in the federal and state courts located in Vermont. You further agree to accept service of process by mail, and hereby waive any and all jurisdictional and venue defenses otherwise available. The Terms and the relationship between you and dOrg shall be governed by the laws of the State of Vermont without regard to conflict of law provisions.
+      </subtitle1>
+
+      <h4 className='pt-8 pb-2 font-bold'>25. RELEASE</h4>
+      <subtitle1 className='leading-7 text-justify'>
+        In addition to the recognition that dOrg is not a party to any Service Contract between Users, you hereby release dOrg, our affiliates, and our respective officers, directors, agents, subsidiaries, joint ventures, and employees from claims, demands, and damages (actual and consequential) of every kind and nature, known and unknown, arising out of or in any way connected with any dispute you have with another User, whether it be at law or in equity. This release includes, for example and without limitation, any disputes regarding the performance, and functions.
+      </subtitle1>
+
+      <h4 className='pt-8 pb-2 font-bold'>26. GENERAL INFORMATION</h4>
+      <subtitle1 className='leading-7 text-justify'>
+        26.1. Entire Agreement<br/>
+        These Terms (and any additional terms, rules and conditions of participation that dOrg may post on the Service) constitute the entire agreement between you and dOrg with respect to the Service and supersedes any prior agreements, oral or written, between you and dOrg. In the event of a conflict between these Terms and the additional terms, rules and conditions of participation, the latter will prevail over the Terms to the extent of the conflict.
+        <br/><br/>
+        26.2. Waiver and Severability of Terms
+        The failure of dOrg to exercise or enforce any right or provision of the Terms shall not constitute a waiver of such right or provision. If any provision of the Terms is found by an arbitrator or court of competent jurisdiction to be invalid, the parties nevertheless agree that the arbitrator or court should endeavor to give effect to the parties' intentions as reflected in the provision, and the other provisions of the Terms remain in full force and effect.
+        <br/><br/>
+        26.3. Statute of Limitations
+        You agree that regardless of any statute or law to the contrary, any claim or cause of action arising out of or related to the use of the Service or the Terms must be filed within one (1) year after such claim or cause of action arose or be forever barred.
+        <br/><br/>
+        26.4. Communications
+        Users with questions, complaints or claims with respect to the Service may contact us at legal@dorg.tech.
+      </subtitle1>
+
+      <h4 className='pt-8 pb-2 font-bold'>27. INTERNATIONAL USERS</h4>
+      <subtitle1 className='leading-7 text-justify'>
+        The Site is controlled, operated and administered by dOrg from its offices within the United States of America and is not intended to subject dOrg to the laws or jurisdiction of any state, country or territory other than that of the United States. dOrg does not represent or warrant that the Site or any part thereof is appropriate or available for use in any particular jurisdiction other than the United States. Those who choose to access the Site do so on their own initiative and at their own risk, and are responsible for complying with all local statutes, orders, regulations, rules, and other laws. You are also subject to United States export controls and are responsible for any violations of such controls, including without limitation any United States embargoes or other federal rules and regulations restricting exports. dOrg may limit the Site’s availability, in whole or in part, to any person, geographic area or jurisdiction we choose, at any time and in our sole discretion.
+      </subtitle1>
+
+      <h4 className='pt-8 pb-2 font-bold'>28. OTHER USER GENERATED CONTENT</h4>
+      <subtitle1 className='leading-7 text-justify'>
+        28.1. Your Responsibility<br/>
+        You are solely responsible for your UGC and the consequences of posting or publishing UGC. By posting or publishing UGC on or through the Service, you affirm, represent, and warrant that: (a) you are the creator of or otherwise own the rights in the UGC that you make available to or through the Service, or, for any UGC that is owned by a third party, you have the express authorization of such third party to upload such UGC to or through the Service; (b) no item of UGC that you upload infringes the intellectual property rights or privacy or any other rights of anyone else or is illegal or breaches the Terms; (c) you waive and agree not to assert any moral rights or similar rights you may have in UGC; (d) you are solely responsible for your UGC, and acknowledge that we do not pre-screen any UGC and do not endorse or approve of any UGC that you or other users may contribute to the Service; (e) you must not in any way claim or suggest that any UGC is endorsed or supported by us; and (f) your use of the Service, including the UGC you upload, complies with all applicable laws and legislation and is not harmful, offensive, defamatory, sexually explicit, obscene, violent, threatening, harassing, abusive, falsely representative of your persona, invasive of someone else’s privacy, illegal or likely to cause any reputational loss or embarrassment to us or our affiliates.
+        <br/><br/>
+        28.2. License Grant to Us<br/>
+        By posting or publishing UGC to the Service or otherwise, you grant us a worldwide, perpetual, non-exclusive, fully transferable, royalty-free, irrevocable, commercial right and license to host, store, use, transfer, display, perform, reproduce, modify, adapt, edit, combine with other materials, publish, distribute, create derivative works from, promote, exhibit, broadcast, syndicate, sublicense (including, without limitation, to third party individuals, media channels, platforms, and distributors), and otherwise use and exploit in any manner whatsoever, or grant third parties the right to do any of the foregoing, to all or any portion of your UGC, for any purpose whatsoever, including for commercial purposes, in any means or media formats and through any media channels (now known or hereafter developed) and to advertise, market, and promote the same. You further irrevocably grant us the right, but not the obligation, to use your name in connection with your UGC. You also agree to waive any right of approval for our use of the rights granted herein that you may have in any UGC, even if it is altered or changed in a manner not agreeable to you. To the extent not waivable, you irrevocably agree not to exercise such rights in a manner that interferes with any exercise of the granted rights. To the extent permitted by applicable laws, you also waive any moral rights or rights of a like nature that you may have in such UGC. Any such use of your UGC by us shall be without any compensation paid to you.
+        <br/><br/>
+        28.3. Use of UGC<br/>
+        USERS OF THE SERVICE CREATE, DOWNLOAD AND USE UGC AT THEIR OWN RISK. WE ARE UNDER NO OBLIGATION TO EDIT OR CONTROL UGC THAT YOU OR OTHER USERS POST OR PUBLISH, AND WILL NOT BE IN ANY WAY RESPONSIBLE OR LIABLE FOR UGC. WE MAY, HOWEVER, AT ANY TIME AND WITHOUT PRIOR NOTICE, SCREEN, REMOVE, EDIT, OR BLOCK ANY UGC THAT IN OUR SOLE JUDGMENT VIOLATES THESE LICENSE TERMS OR IS OTHERWISE OBJECTIONABLE. YOU UNDERSTAND THAT WHEN USING THE SERVICE YOU WILL BE EXPOSED TO UGC FROM A VARIETY OF SOURCES AND ACKNOWLEDGE THAT UGC MAY BE INACCURATE, OFFENSIVE, INDECENT OR OBJECTIONABLE. YOU AGREE TO WAIVE, AND DO HEREBY WAIVE, ANY LEGAL OR EQUITABLE RIGHTS OR REMEDIES YOU HAVE OR MAY HAVE AGAINST US WITH RESPECT TO UGC. WE EXPRESSLY DISCLAIM ANY AND ALL LIABILITY IN CONNECTION WITH UGC. IF NOTIFIED BY A USER OR CONTENT OWNER THAT UGC ALLEGEDLY DOES NOT CONFORM TO THE LICENSE TERMS, WE MAY INVESTIGATE THE ALLEGATION AND DETERMINE IN OUR SOLE DISCRETION WHETHER TO REMOVE THE UGC, WHICH WE RESERVE THE RIGHT TO DO AT ANY TIME AND WITHOUT NOTICE. FOR CLARITY, WE DO NOT PERMIT COPYRIGHT-INFRINGING ACTIVITIES ON THE SERVICE.
+      </subtitle1>
+
+      <h4 className='pt-8 pb-2 font-bold'>29. ADDITIONAL SERVICES</h4>
+      <subtitle1 className='leading-7 text-justify'>
+        29.1. License to Your Materials
+        You hereby grant to dOrg a non-exclusive, non-transferable license to use the logos, trademarks, service marks, trade dress and other protectable source or business identifiers, and any documents, information and other materials owned or licensed by you and provided by you to dOrg for use in connection with the Additional Services. Except as specifically set forth above, neither party will acquire any right, title or interest in the other party’s trademarks, service marks, trade secrets, logos, commercial symbols, copyrights, patents and any other intellectual property rights by virtue of the provisions hereunder.
+        <br/><br/>
+        29.2 Publicity
+        You agree not to issue any press release or otherwise make any public announcement related to the Additional Services or the transactions contemplated in the order forms without the prior written approval of dOrg.
+      </subtitle1>
+    </>
+// ------------------------------------------------------------------------------------------------------- //
+
+export default TermsText;

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -8,6 +8,7 @@ module.exports = {
         indigoDD: '#3c1dfe',
         indigoDD2: '#2713A5',
         indigoDD3: '#361AE5',
+        indigoDD4: '#21108C',
         aquaDD: '#2bfae1',
         aquaDD2: '#14CDB7',
         magentaDD: '#ff6ce1',
@@ -39,6 +40,7 @@ module.exports = {
       screens: {
         'xs': '400px',
         '500px': '500px',
+        '550px': '550px',
         '600px': '600px',
         '700px': '700px',
         '800px': '800px',


### PR DESCRIPTION
- Phase1&2: added Terms & Conditions page, checkbox on phase1 form & note on phase2
- Redirected all routes except (/terms) to the main page
- Updated meta description & urls
- Removed gitcoin from form, text change for nomination and allocation phase (above timer), changed funded to supported
- Pause: changed color & hover of twitter link text
- Phase1&2: Implemented error popup when submitting nominations or points fail with a 500 server error. If the points submission fails, it automatically clears the cache and disconnects the wallet.
- Phase1: changed description char limit to 1000 & added Char Left count
- Phase1&Pause: smaller (built by … & twitter icon) on mobile view
- Phase2: disable the hover effect on the Done button after votes submit
- Phase2&3: Fixed background icons overflow when the projects number is low
- Phase2&3: reset (points & votes) states when the address is disconnected
- Phase3: smaller “check results” button on mobile view
- Phase3: added usdc amount to the project card (usdc = (projectScore / scoreSum) * 250000). There is an alternative option to fetch it from the database.
- Phase3: Voted icon is hidden when the address is disconnected
- Disabled auto zoom on mobile view
